### PR TITLE
feat(Support for local and live tables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,16 @@
 # Steampipe AWS Security Hub Mod
 
-This mod fetches security findings from AWS Security Hub and provides different views to analyze them. Some views combine findings with other sources informations to provide more context, for example tagging.
+This mod fetches security findings from AWS Security Hub and provides different views to analyze them. Some views combine findings with other sources of information to provide more context, for example, by querying the tagging directly in the affected resource.
 
-At the moment, only findings with the record state `ACTIVE` are fetched, this will be configurable in the future, but for visualizing findings, this is the most common use case (active findings).
-
-You can filter the findings by severity, workflow status, compliance status, etc. The filters are available in the top of the dashboard. Some filters options are fixed when the posible values are known, for example, the workflow status: `NEW`, `NOTIFIED`, `RESOLVED`, `SUPPRESSED`. Other filters are set to `ALL` as a wildcard and you can write the value you want to filter by, for example, the resource type. This is for performance reasons. Maybe in the future those values could be populated dynamically.
-
-## Available Dashboards
+Dashboards can be filtered by severity, workflow status, compliance status, resource type, etc. The filters are available at the top of each dashboard.
 
 [Security Hub Findings](dashboards/securityhub_findings.sp): This dashboard provides a view of all security findings in your AWS Security Hub account.
 
 <img src="docs/securityhub_findings.png" width="50%" type="thumbnail"/>
 
-[Security Hub Findings with Tags](dashboards/securityhub_findings_with_tags.sp): This dashboard provides a view of all security findings in your AWS Security Hub account and combine them with tags information by correlating with the information available in the AWS Resource Groups Tagging API (joining by ARN).
+[Security Hub Findings with Tags](dashboards/securityhub_findings_with_tags.sp): This dashboard provides a view of all security findings in your AWS Security Hub account and combines them with tags information by correlating with the information available in the AWS Resource Groups Tagging API (joining by ARN).
 
 <img src="docs/securityhub_findings_with_tags.png" width="50%" type="thumbnail"/>
-
-## To Do
-
-- [ ] Filters and Graphs by Tags dimensions
-- [ ] Add more dashboards
-- [ ] Add custom metrics, like Time to Fix or Time to Notify
-- [ ] Make the initial query for fetching findigns customizable (e.g. by record state)
-- [ ] Documentation
 
 ## Getting started
 
@@ -32,7 +20,7 @@ Download and install Steampipe (https://steampipe.io/downloads). Or use Brew:
 
 ```sh
 brew tap turbot/tap
-brew install steampipe
+brew install Steampipe
 ```
 
 Install the AWS plugin with [Steampipe](https://steampipe.io):
@@ -45,7 +33,7 @@ Clone:
 
 ```sh
 git clone https://github.com/gabrielsoltz/steampipe-mod-aws-securityhub
-cd steampipe-mod-aws-securityhub
+cd steampipe-mod-aws-security hub
 ```
 
 ### Usage
@@ -56,10 +44,67 @@ Start your dashboard server to get started:
 steampipe dashboard
 ```
 
-### Credentials
+## Credentials
 
 This mod uses the credentials configured in the [Steampipe AWS plugin](https://hub.steampipe.io/plugins/turbot/aws).
 
-### Configuration
+## Dashboard Configuration
 
-No extra configuration is required.
+### AWS Security Hub Master Account
+
+AWS Security Hub can show findings from the same account running or configured to aggregate findings from multiple accounts and regions. If this is your case, continue reading.
+
+When reading from AWS Security Hub, which is from multiple accounts, you need to specify the steampipe connection to that account in this mod and avoid using an aggregator, as performance will be drastically affected, and findings could be duplicated.
+
+To define the connector for the master account, you need to set the variable `sh_findings_connection_table` in the `mod.sp` file. The value of this variable is the connector and the table name, which you don't need to change.
+
+### AWS Security Hub Region Aggregator
+
+If aggregating findings from multiple regions, you must also define the master region in the `mod.sp` file using the variable `sh_aggregator_region.` If you are not aggregating findings, you can leave this variable as `ALL`
+
+## Generate Local Tables
+
+Working with security findings can be slow, especially if you have many accounts and findings. To improve performance, you can generate a local table with the findings and use that table in your queries. So you only download the data once, and then you query locally. You can regenerate the table as many times as you want to refresh the data when updating it.
+
+For generating the local tables, the script `generate_findings_local.sh` under the `scripts` folder will create both tables needed in your Steampipe locally.
+
+YOU NEED TO CONFIGURE THE VARIABLES IN THE SCRIPT BEFORE RUNNING IT.
+
+```sh
+$ sh scripts/generate_findings_local.sh
+Creating Table: local_aws_securityhub_finding
+Ok
+Creating Table: local_aws_tagging_resource
+Ok
+```
+
+Once the tables are created, you need to define them using the variables `sh_findings_connection_table` and `aws_tagging_resources_table` like this:
+
+```hcl
+variable "sh_findings_connection_table" {
+  type = string
+  default = "public.local_aws_securityhub_finding"
+}
+
+
+variable "aws_tagging_resources_table" {
+  type = string
+  default = "public.local_aws_tagging_resource"
+}
+```
+
+## To Do
+
+- [ ] Filters and Graphs by Tags dimensions
+- [ ] Add more dashboards
+- [ ] Add custom metrics, like Time to Fix or Time to Notify
+- [ ] Make the initial query for fetching findings customizable (e.g., by record state)
+- [ ] Documentation
+
+## Filters
+
+Some filter options are fixed when the possible values are known, for example, the workflow status: `NEW,` `NOTIFIED,` `RESOLVED,` and `SUPPRESSED.` Other filters are set to `ALL` as a wildcard, and you can write the value you want to filter by, for example, the resource type. This is for performance reasons. In the future, those values could be populated dynamically.
+
+## Active Findings
+
+Currently, only findings with the record state `ACTIVE` are fetched; this will be configurable in the future, but for visualizing findings, this is the most common use case (active findings).

--- a/dashboards/securityhub.sp
+++ b/dashboards/securityhub.sp
@@ -1,0 +1,109 @@
+locals {
+  sh_findings_sql = <<-EOQ
+    select
+      f.title as title,
+      f.severity ->> 'Original' as severity,
+      f.workflow_status as workflow_status,
+      f.compliance_status as compliance_status,
+      f.source_account_id as resource_account,
+      f.region as sh_region,
+      f.record_state as record_state,
+      r ->> 'Type' as resource_type,
+      r ->> 'Id' as resource_id,
+      r ->> 'Region' as resource_region
+    from
+      __TABLE_NAME__ as f,
+      jsonb_array_elements(resources) r
+  EOQ
+}
+
+locals {
+  sh_findings_count_sql = <<-EOQ
+  with sh_findings as (${replace(local.sh_findings_sql, "__TABLE_NAME__", var.sh_findings_connection_table)})
+  select
+  count(*)
+  from
+  sh_findings
+    where
+      record_state = 'ACTIVE'
+      and severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity)
+      and workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status)
+      and compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status)
+      and ($4 = 'ALL' OR resource_type IN (SELECT UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type))
+      and ($5 = 'ALL' OR resource_region IN (SELECT UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region))
+      and ($6 = 'ALL' OR resource_account IN (SELECT UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account))
+  EOQ
+  sh_findings_group_sql = <<-EOQ
+  with sh_findings as (${replace(local.sh_findings_sql, "__TABLE_NAME__", var.sh_findings_connection_table)})
+  select
+  __GROUP_BY__, count(*) as Total
+  from
+  sh_findings
+    where
+      record_state = 'ACTIVE'
+      and severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity)
+      and workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status)
+      and compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status)
+      and ($4 = 'ALL' OR resource_type IN (SELECT UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type))
+      and ($5 = 'ALL' OR resource_region IN (SELECT UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region))
+      and ($6 = 'ALL' OR resource_account IN (SELECT UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account))
+  group by
+    __GROUP_BY__
+  order by
+    Total desc
+  EOQ
+  sh_findings_table_sql = <<-EOQ
+  with sh_findings as (${replace(local.sh_findings_sql, "__TABLE_NAME__", var.sh_findings_connection_table)})
+  select
+  *
+  from
+  sh_findings
+    where
+      record_state = 'ACTIVE'
+      and severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity)
+      and workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status)
+      and compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status)
+      and ($4 = 'ALL' OR resource_type IN (SELECT UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type))
+      and ($5 = 'ALL' OR resource_region IN (SELECT UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region))
+      and ($6 = 'ALL' OR resource_account IN (SELECT UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account))
+  EOQ
+}
+
+locals {
+  tagging_resources_sql = <<-EOQ
+    select
+      a.arn,
+      a.tags
+    from
+      __TABLE_NAME__ as a
+  EOQ
+}
+
+locals {
+  sh_findings_table_with_tags_sql = <<-EOQ
+  with sh_findings as (${replace(local.sh_findings_sql, "__TABLE_NAME__", var.sh_findings_connection_table)}),
+  tag_resources as (${replace(local.tagging_resources_sql, "__TABLE_NAME__", var.aws_tagging_resources_table)})
+  select
+    f.title,
+    f.severity,
+    f.workflow_status as workflow_status,
+    f.compliance_status as compliance_status,
+    f.resource_account as resource_account,
+    f.record_state as record_state,
+    f.resource_type as resource_type,
+    f.resource_id as resource_id,
+    f.resource_region as resource_region,
+    a.tags
+  from sh_findings f
+  left join tag_resources a ON f.resource_id = a.arn
+    where
+      f.record_state = 'ACTIVE'
+      and f.severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity)
+      and f.workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status)
+      and f.compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status)
+      and ($4 = 'ALL' OR f.resource_type IN (SELECT UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type))
+      and ($5 = 'ALL' OR f.resource_region IN (SELECT UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region))
+      and ($6 = 'ALL' OR f.resource_account IN (SELECT UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account))
+  EOQ
+
+}

--- a/dashboards/securityhub_findings.sp
+++ b/dashboards/securityhub_findings.sp
@@ -265,318 +265,8 @@ dashboard "securityhub_findings" {
 
 }
 
-# To do: Maybe one only query with all the group bys that could be used for all the charts.
-
-query "findings_group_by_severity" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      severity,
-      count (*) as Total
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-    group by
-      severity
-    order by
-      Total desc
-EOQ
-
-  param "severity" {}
-  param "workflow_status" {}
-  param "compliance_status" {}
-  param "resource_type" {}
-  param "resource_region" {}
-  param "resource_account" {}
-}
-
-query "findings_group_by_workflow_status" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      workflow_status,
-      count (*) as Total
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-    group by
-      workflow_status
-    order by
-      Total desc
-EOQ
-
-  param "severity" {}
-  param "workflow_status" {}
-  param "compliance_status" {}
-  param "resource_type" {}
-  param "resource_region" {}
-  param "resource_account" {}
-}
-
-query "findings_group_by_compliance_status" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      compliance_status,
-      count (*) as Total
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-    group by
-      compliance_status
-    order by
-      Total desc
-EOQ
-
-  param "severity" {}
-  param "workflow_status" {}
-  param "compliance_status" {}
-  param "resource_type" {}
-  param "resource_region" {}
-  param "resource_account" {}
-}
-
-query "findings_group_by_resource_type" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      resource_type,
-      count (*) as Total
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-    group by
-      resource_type
-    order by
-      Total desc
-EOQ
-
-  param "severity" {}
-  param "workflow_status" {}
-  param "compliance_status" {}
-  param "resource_type" {}
-  param "resource_region" {}
-  param "resource_account" {}
-}
-
-query "findings_group_by_resource_region" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      resource_region,
-      count (*) as Total
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-    group by
-      resource_region
-    order by
-      Total desc
-EOQ
-
-  param "severity" {}
-  param "workflow_status" {}
-  param "compliance_status" {}
-  param "resource_type" {}
-  param "resource_region" {}
-  param "resource_account" {}
-}
-
-query "findings_group_by_resource_account" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      resource_account,
-      count (*) as Total
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-    group by
-      resource_account
-    order by
-      Total desc
-EOQ
-
+query "findings_table" {
+  sql = local.sh_findings_table_sql
   param "severity" {}
   param "workflow_status" {}
   param "compliance_status" {}
@@ -586,50 +276,7 @@ EOQ
 }
 
 query "findings_count" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      'Findings' as label,
-      count (*) as value,
-      case
-          when count(*) > 0 then 'alert'
-          else 'ok'
-      end as type
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-EOQ
-
+  sql = local.sh_findings_count_sql
   param "severity" {}
   param "workflow_status" {}
   param "compliance_status" {}
@@ -638,55 +285,58 @@ EOQ
   param "resource_account" {}
 }
 
-query "findings_table" {
-  sql = <<-EOQ
-    with findings as (
-      select
-        f.title,
-        f.severity ->> 'Original' as severity,
-        f.workflow_status,
-        f.compliance_status,
-        f.source_account_id as resource_account,
-        f.region as sh_region,
-        r ->> 'Type' as resource_type,
-        r ->> 'Id' as resource_id,
-        r ->> 'Region' as resource_region
-      from
-        aws_securityhub_finding f,
-        jsonb_array_elements(resources) r
-      where
-        record_state = 'ACTIVE'
-    )
-    select
-      resource_id,
-      title,
-      resource_region,
-      resource_account,
-      severity,
-      workflow_status,
-      compliance_status,
-      resource_type,
-      sh_region
-    from
-      findings
-    where
-      severity in (select UNNEST(STRING_TO_ARRAY($1, ',')) AS severity) and
-      workflow_status in (select UNNEST(STRING_TO_ARRAY($2, ',')) AS workflow_status) and
-      compliance_status in (select UNNEST(STRING_TO_ARRAY($3, ',')) AS compliance_status) and
-    case
-        WHEN $4 <> 'ALL' THEN resource_type in (select UNNEST(STRING_TO_ARRAY($4, ',')) AS resource_type)
-        ELSE true
-    end and
-    case
-        WHEN $5 <> 'ALL' THEN resource_region in (select UNNEST(STRING_TO_ARRAY($5, ',')) AS resource_region)
-        ELSE true
-    end and
-    case
-        WHEN $6 <> 'ALL' THEN resource_account in (select UNNEST(STRING_TO_ARRAY($6, ',')) AS resource_account)
-        ELSE true
-    end
-EOQ
+query "findings_group_by_severity" {
+  sql = replace(local.sh_findings_group_sql, "__GROUP_BY__", "severity")
+  param "severity" {}
+  param "workflow_status" {}
+  param "compliance_status" {}
+  param "resource_type" {}
+  param "resource_region" {}
+  param "resource_account" {}
+}
 
+query "findings_group_by_resource_account" {
+  sql = replace(local.sh_findings_group_sql, "__GROUP_BY__", "resource_account")
+  param "severity" {}
+  param "workflow_status" {}
+  param "compliance_status" {}
+  param "resource_type" {}
+  param "resource_region" {}
+  param "resource_account" {}
+}
+
+query "findings_group_by_workflow_status" {
+  sql = replace(local.sh_findings_group_sql, "__GROUP_BY__", "workflow_status")
+  param "severity" {}
+  param "workflow_status" {}
+  param "compliance_status" {}
+  param "resource_type" {}
+  param "resource_region" {}
+  param "resource_account" {}
+}
+
+query "findings_group_by_compliance_status" {
+  sql = replace(local.sh_findings_group_sql, "__GROUP_BY__", "compliance_status")
+  param "severity" {}
+  param "workflow_status" {}
+  param "compliance_status" {}
+  param "resource_type" {}
+  param "resource_region" {}
+  param "resource_account" {}
+}
+
+query "findings_group_by_resource_type" {
+  sql = replace(local.sh_findings_group_sql, "__GROUP_BY__", "resource_type")
+  param "severity" {}
+  param "workflow_status" {}
+  param "compliance_status" {}
+  param "resource_type" {}
+  param "resource_region" {}
+  param "resource_account" {}
+}
+
+query "findings_group_by_resource_region" {
+  sql = replace(local.sh_findings_group_sql, "__GROUP_BY__", "resource_region")
   param "severity" {}
   param "workflow_status" {}
   param "compliance_status" {}

--- a/mod.sp
+++ b/mod.sp
@@ -6,8 +6,30 @@ locals {
   }
 }
 
+# The AWS Security Hub Findings Table and Connection (connection.table)
+# Example AWS: aws_sh_master.aws_securityhub_finding
+# Example Local: public.local_aws_securityhub_finding
+variable "sh_findings_connection_table" {
+  type = string
+  default = "aws_sh_master.aws_securityhub_finding"
+}
+
+# The AWS Tagging Table and Connection (connection.table)
+# Example AWS: aws.aws_tagging_resource
+# Example Local: public.local_aws_tagging_resource
+variable "aws_tagging_resources_table" {
+  type = string
+  default = "aws.aws_tagging_resource"
+}
+
+# AWS Security Hub Aggregator Region.
+# If you are not aggregating findings from multiple accounts use: "ALL"
+variable "sh_aggregator_region" {
+  type = string
+  default = "eu-west-1"
+}
+
 mod "aws_securityhub" {
-  # hub metadata
   title         = "Steampipe Mod for AWS Security Hub"
   description   = "AWS Security Hub Mod"
   color         = "#FF9900"
@@ -20,5 +42,4 @@ mod "aws_securityhub" {
     description = "AWS Security Hub Mod"
     image       = ""
   }
-
 }

--- a/scripts/generate-findings-local.sh
+++ b/scripts/generate-findings-local.sh
@@ -1,0 +1,35 @@
+# This script will create a local table from the live AWS Security Hub table
+# Once the table is created, modify the variable in the file mod.sp with the name of the local table.
+
+# If you are using workspaces, you can set the workspace name here, use "default" if not.
+export STEAMP_WORKSPACE="securityhub"
+
+# Security Hub findings Table
+export TABLE="aws_securityhub_finding"
+# Set the name of the aws plugin connection for the Security Hub master table in case you are aggregating findings.
+# If you are not aggregating findings in a master account, you can use here a steampipe aggregator (like aws_all) or any connetion.
+export STEAMP_AWS_CON_SH_MASTER="aws_sh_master"
+# We only fetch active findings, but you can change this to any valid SQL WHERE clause.
+export WHERE_CLAUSE="WHERE record_state = 'ACTIVE'"
+# Set the name of the local table
+export LOCAL_TABLE="local_aws_securityhub_finding"
+
+echo "Creating Table: $LOCAL_TABLE"
+steampipe --workspace $STEAMP_WORKSPACE query "DROP TABLE IF EXISTS $LOCAL_TABLE;" && \
+steampipe --workspace $STEAMP_WORKSPACE query "CREATE TABLE $LOCAL_TABLE AS select * FROM $STEAMP_AWS_CON_SH_MASTER.$TABLE $WHERE_CLAUSE;" && \
+echo "Ok" || echo "Error"
+
+# Tagging Table
+export TABLE="aws_tagging_resource"
+# Set the connection for the table tagging.
+# In this case, if you are aggregating findings from different accounts, you will need to use here an steampipe connection aggregator.
+# This is because the resources are not in the same account as Security Hub.
+# If you are running Security Hub in a single account, here use the same connection as the Security Hub master table.
+export STEAMP_AWS_CON_SH_MASTER="aws_sh_master"
+# Set the name of the local table
+export LOCAL_TABLE="local_aws_tagging_resource"
+
+echo "Creating Table: $LOCAL_TABLE"
+steampipe --workspace $STEAMP_WORKSPACE query "DROP TABLE IF EXISTS $LOCAL_TABLE;" && \
+steampipe --workspace $STEAMP_WORKSPACE query "CREATE TABLE $LOCAL_TABLE AS select * FROM $STEAMP_AWS_CON_SH_MASTER.$TABLE;" && \
+echo "Ok" || echo "Error"


### PR DESCRIPTION
- Now, it is possible to define the connection and table name for the main tables using a variable. This way, you can configure to use the steampipe aws plugin connector that you need instead of the default. Read the documentation to understand which one to use. 

- The mod now provides a script for generating local tables automatically. This way, you can use the Mod querying locally for extreme speed. Navigating the dashboards with local data is instant. The mod supports defining either the live or local table by defining a variable. 

- All queries now depend on locals, meaning that we removed a ton of duplicated queries. Now we define the queries once, and we re-use them where needed. 